### PR TITLE
Audit branch

### DIFF
--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -37,6 +37,20 @@ options:
       - The path to the root of the Terraform directory with the
         vars.tf/main.tf/etc to use.
     required: true
+  plan_id:
+    description:
+      - A plan_id linked to a temporary plan file created if no plan_path
+        is specified
+    required: false
+  log_activity_folder:
+    description:
+        - The path to a folder to create the logging file. If path does not exist,it is created.
+        If not specified, the current directory will be used to store the logging file.
+    required: false
+  file_name:
+    description:
+      - A string to name the logging file with. If not specified, a default name 'audit' will be specified.
+    required: false
   workspace:
     description:
       - The terraform workspace to work with.
@@ -168,15 +182,16 @@ module = None
 
 
 def preflight_validation(module, bin_path, project_path, variables_args=None, plan_file=None):
-    if (project_path in [None, ''] or '/' not in project_path and bin_path in [None, '']) or (project_path not in [None, ''] and bin_path in [None, '']) or (project_path in [None, ''] and bin_path not in [None, '']):
-        module.fail_json(msg="Paths for both project_path and bin_path cannot be None or ''.")
-    elif project_path not in [None, ''] or '/' in project_path and bin_path not in [None, '']:
-        if (not os.path.exists(bin_path) and not os.path.exists(project_path)) or (os.path.exists(bin_path) and not os.path.exists(project_path)) or (not os.path.exists(bin_path) and os.path.exists(project_path)):
-            module.fail_json(msg="Path for Terraform binary or project path '{0}' doesn't exist on this host: paths_provided - (terraform-binary-path: '{0}' project-path: '{1}') - check the paths and try again please.".format(bin_path, project_path))
-        else:
-            rc, out, err = module.run_command([bin_path, 'validate'] + variables_args, cwd=project_path, use_unsafe_shell=True)
-            if rc != 0:
-                module.fail_json(msg="Failed to validate Terraform configuration files:\r\n{0}".format(err))
+    if project_path in [None, ''] or '/' not in project_path:
+        module.fail_json(msg="Path for Terraform project can not be None or ''.")
+    if not os.path.exists(bin_path):
+        module.fail_json(msg="Path for Terraform binary '{0}' doesn't exist on this host - check the path and try again please.".format(bin_path))
+    if not os.path.isdir(project_path):
+        module.fail_json(msg="Path for Terraform project '{0}' doesn't exist on this host - check the path and try again please.".format(project_path))
+
+    rc, out, err = module.run_command([bin_path, 'validate'] + variables_args, cwd=project_path, use_unsafe_shell=True)
+    if rc != 0:
+        module.fail_json(msg="Failed to validate Terraform configuration files:\r\n{0}".format(err))
 
 
 def _state_args(module, state_file):
@@ -262,16 +277,18 @@ def build_plan(module, command, project_path, variables_args, state_file, target
 
     module.fail_json(msg='Terraform plan failed with unexpected exit code {0}. \r\nSTDOUT: {1}\r\n\r\nSTDERR: {2}'.format(rc, out, err))
 
-def return_full_path(log_activity_folder, service_id):
+
+def return_full_path(log_activity_folder, file_name):
     if log_activity_folder[-1] != '/':
-        full_path = log_activity_folder + '/'+ service_id
+        full_path = log_activity_folder + '/' + file_name + '.json'
     else:
-        full_path = log_activity_folder + service_id
+        full_path = log_activity_folder + file_name + '.json'
 
     return full_path
 
-def create_audit_file_and_directory(log_activity_folder, service_id):
-    full_path = return_full_path(log_activity_folder, service_id)
+
+def create_logging_file_and_directory(log_activity_folder, file_name):
+    full_path = return_full_path(log_activity_folder, file_name)
     if not os.path.exists(log_activity_folder):
         os.makedirs(log_activity_folder)
 
@@ -280,8 +297,8 @@ def create_audit_file_and_directory(log_activity_folder, service_id):
             json.dump([], file_created, indent=4)
 
 
-def audit(log_activity_folder, service_id, plan_used, command_run, stdout):
-    path_to_audit_file = return_full_path(log_activity_folder, service_id)
+def logging(log_activity_folder, file_name, plan_used, command_run, stdout):
+    path_to_audit_file = return_full_path(log_activity_folder, file_name)
     timestamp = time.strftime('%d-%m-%Y %H:%M:%S')
     command_used = command_run[1]
     outcome = ''
@@ -308,14 +325,13 @@ def audit(log_activity_folder, service_id, plan_used, command_run, stdout):
             if line.startswith('Plan:') or line.startswith('No changes'):
                 outcome = line
     items_to_write = {
-            'time': timestamp,
-            'plan_used': plan_used,
-            'command_run': command_used,
-            'outcome': outcome,
-            'resources_added': list_creation,
-            'resources_changed': list_modification,
-            'resources_destroyed': list_destruction
-            }
+        'time': timestamp,
+        'plan_used': plan_used,
+        'command_run': command_used,
+        'outcome': outcome,
+        'resources_added': list_creation,
+        'resources_changed': list_modification,
+        'resources_destroyed': list_destruction}
 
     with open(path_to_audit_file, 'r') as file_opened:
         data_stored = json.load(file_opened)
@@ -325,13 +341,14 @@ def audit(log_activity_folder, service_id, plan_used, command_run, stdout):
     with open(path_to_audit_file, 'w') as file_opened:
         json.dump(data_stored, file_opened, indent=4)
 
+
 def get_plan_file_name_without_extension(plan_file_path):
     file_name, extension = os.path.basename(plan_file_path).split(".")
     return file_name
 
 
-def get_plans_used(log_activity_folder, service_id):
-    log_activity_path = return_full_path(log_activity_folder, service_id)
+def get_plans_used(log_activity_folder, file_name):
+    log_activity_path = return_full_path(log_activity_folder, file_name)
     plans = []
     with open(log_activity_path, 'r') as file_opened:
         data_stored = json.load(file_opened)
@@ -340,11 +357,12 @@ def get_plans_used(log_activity_folder, service_id):
             plans.append(record)
     return plans
 
-def get_plan_file_from_audit_file(log_activity_folder, service_id, plan_id):
-    log_activity_path = return_full_path(log_activity_folder, service_id)
+
+def get_plan_file_from_logging_file(log_activity_folder, file_name, plan_id):
+    log_activity_path = return_full_path(log_activity_folder, full_name)
     all_entries_with_file = []
     search_file_path = '/tmp/{0}.tfplan'.format(plan_id)
-    for i in get_plans_used(log_activity_folder, service_id):
+    for i in get_plans_used(log_activity_folder, file_name):
         if search_file_path in i.values():
             all_entries_with_file.append(i)
     if all_entries_with_file:
@@ -354,14 +372,14 @@ def get_plan_file_from_audit_file(log_activity_folder, service_id, plan_id):
 
 
 def main():
-    message=""
+    message = ""
     global module
     module = AnsibleModule(
         argument_spec=dict(
             project_path=dict(required=True, type='path'),
             plan_id=dict(type='str'),
-            log_activity_folder=dict(required=True, type='path'),
-            service_id=dict(required=True, type='str'),
+            log_activity_folder=dict(type='path'),
+            file_name=dict(type='str'),
             binary_path=dict(type='path'),
             workspace=dict(required=False, type='str', default='default'),
             purge_workspace=dict(type='bool', default=False),
@@ -376,7 +394,6 @@ def main():
             force_init=dict(type='bool', default=False),
             backend_config=dict(type='dict', default=None),
         ),
-        #required_if=[('state', 'planned', ['plan_file'])],
         supports_check_mode=True,
     )
 
@@ -393,8 +410,13 @@ def main():
     backend_config = module.params.get('backend_config')
     plan_id = module.params.get('plan_id')
     log_activity_folder = module.params.get('log_activity_folder')
-    service_id = module.params.get('service_id')
+    file_name = module.params.get('file_name')
 
+    if not log_activity_folder:
+        log_activity_folder = './'
+
+    if not file_name:
+        file_name = 'audit'
 
     if bin_path is not None:
         command = [bin_path]
@@ -443,7 +465,7 @@ def main():
 
     out, err = '', ''
 
-    create_audit_file_and_directory(log_activity_folder, service_id)
+    create_logging_file_and_directory(log_activity_folder, file_name)
 
     if state == 'absent':
         command.extend(variables_args)
@@ -453,30 +475,33 @@ def main():
         else:
             module.fail_json(msg='Could not find plan_file "{0}", check the path and try again.'.format(plan_file))
     elif state == 'present' and plan_id:
-        plan_file = get_plan_file_from_audit_file(log_activity_folder, service_id, plan_id)
+        plan_file = get_plan_file_from_logging_file(log_activity_folder, file_name, plan_id)
         if plan_file:
             command.append(plan_file)
-            message="running apply with plan_id: {0}".format(plan_id)
+            message = "running apply with plan_id: {0}".format(plan_id)
         else:
             module.fail_json(msg="plan file with id does not exist!")
     elif state == 'present' and not plan_id:
-        last_plan_used = get_plans_used(log_activity_folder, service_id)
+        last_plan_used = get_plans_used(log_activity_folder, file_name)
         if last_plan_used:
-            message="no plan file specified. running 'apply' with plan created from recently run 'plan' command with id: {}".format(get_plan_file_name_without_extension(last_plan_used[-1]['plan_used']))
+            message = "no plan file specified. running 'apply' with plan created from recently run 'plan' \
+            command with id: {}".format(get_plan_file_name_without_extension(last_plan_used[-1]['plan_used']))
             command.append(last_plan_used[-1]['plan_used'])
             plan_file = last_plan_used[-1]['plan_used']
         else:
-            #no plan command run yet
-            plan_file, needs_application, out, err, command = build_plan(module, command, project_path, variables_args, state_file,module.params.get('targets'), state, plan_file)
+            # no plan command run yet
+            plan_file, needs_application, out, err, command = build_plan(
+                module, command, project_path,
+                variables_args, state_file, module.params.get('targets'), state, plan_file)
             command.append(plan_file)
-            message="running apply without having run plan before"
+            message = "running apply without having run plan before"
 
     else:
-        plan_file, needs_application, out, err, command = build_plan(module, command, project_path, variables_args, state_file,module.params.get('targets'), state, plan_file)
+        plan_file, needs_application, out, err, command = build_plan(
+                                                        module, command, project_path,
+                                                        variables_args, state_file, module.params.get('targets'), state, plan_file)
         command.append(plan_file)
-        message="plan command executed. plan_id generated: {0}".format(get_plan_file_name_without_extension(plan_file))
-
-
+        message = "plan command executed. plan_id generated: {0}".format(get_plan_file_name_without_extension(plan_file))
 
     if needs_application and not module.check_mode and not state == 'planned':
         rc, out, err = module.run_command(command, cwd=project_path)
@@ -508,7 +533,7 @@ def main():
     if state == 'absent' and workspace != 'default' and purge_workspace is True:
         remove_workspace(command[0], project_path, workspace)
 
-    audit(log_activity_folder, service_id, plan_file, command, out)
+    logging(log_activity_folder, file_name, plan_file, command, out)
 
     module.exit_json(changed=changed, message=message, state=state, workspace=workspace, outputs=outputs, stdout=out, stderr=err, command=' '.join(command))
 

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -8,11 +8,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
-
 DOCUMENTATION = '''
 ---
 module: terraform
@@ -25,43 +20,25 @@ options:
     choices: ['planned', 'present', 'absent']
     description:
       - Goal state of given stage/project
-    required: false
     default: present
   binary_path:
     description:
       - The path of a terraform binary to use, relative to the 'service_path'
         unless you supply an absolute path.
-    required: false
   project_path:
     description:
       - The path to the root of the Terraform directory with the
         vars.tf/main.tf/etc to use.
     required: true
-  plan_id:
-    description:
-      - A plan_id linked to a temporary plan file created if no plan_path
-        is specified
-    required: false
-  log_activity_folder:
-    description:
-        - The path to a folder to create the logging file. If path does not exist,it is created.
-        If not specified, the current directory will be used to store the logging file.
-    required: false
-  file_name:
-    description:
-      - A string to name the logging file with. If not specified, a default name 'audit' will be specified.
-    required: false
   workspace:
     description:
       - The terraform workspace to work with.
-    required: false
     default: default
   purge_workspace:
     description:
       - Only works with state = absent
       - If true, the workspace will be deleted after the "terraform destroy" action.
       - The 'default' workspace will not be deleted.
-    required: false
     default: false
     type: bool
   plan_file:
@@ -69,51 +46,53 @@ options:
       - The path to an existing Terraform plan file to apply. If this is not
         specified, Ansible will build a new TF plan and execute it.
         Note that this option is required if 'state' has the 'planned' value.
-    required: false
   state_file:
     description:
       - The path to an existing Terraform state file to use when building plan.
         If this is not specified, the default `terraform.tfstate` will be used.
       - This option is ignored when plan is specified.
-    required: false
-  variables_file:
+  variables_files:
     description:
       - The path to a variables file for Terraform to fill into the TF
-        configurations.
-    required: false
+        configurations. This can accept a list of paths to multiple variables files.
+      - Up until Ansible 2.9, this option was usable as I(variables_file).
+    type: list
+    elements: path
+    aliases: [ 'variables_file' ]
   variables:
     description:
       - A group of key-values to override template variables or those in
         variables files.
-    required: false
   targets:
     description:
       - A list of specific resources to target in this plan/application. The
         resources selected here will also auto-include any dependencies.
-    required: false
   lock:
     description:
       - Enable statefile locking, if you use a service that accepts locks (such
         as S3+DynamoDB) to store your statefile.
-    required: false
     type: bool
   lock_timeout:
     description:
       - How long to maintain the lock on the statefile, if you use a service
         that accepts locks (such as S3+DynamoDB).
-    required: false
   force_init:
     description:
       - To avoid duplicating infra, if a state file can't be found this will
         force a `terraform init`. Generally, this should be turned off unless
         you intend to provision an entirely new Terraform deployment.
     default: false
-    required: false
     type: bool
   backend_config:
     description:
       - A group of key-values to provide at init stage to the -backend-config parameter.
-    required: false
+  backend_config_files:
+    description:
+      - The path to a configuration file to provide at init state to the -backend-config parameter.
+        This can accept a list of paths to multiple configuration files.
+    type: list
+    elements: path
+    version_added: '0.2.0'
 notes:
    - To just run a `terraform plan`, use check mode.
 requirements: [ "terraform" ]
@@ -121,13 +100,13 @@ author: "Ryan Scott Brown (@ryansb)"
 '''
 
 EXAMPLES = """
-# Basic deploy of a service
-- terraform:
+- name: Basic deploy of a service
+  terraform:
     project_path: '{{ project_dir }}'
     state: present
 
-# Define the backend configuration at init
-- terraform:
+- name: Define the backend configuration at init
+  terraform:
     project_path: 'project/'
     state: "{{ state }}"
     force_init: true
@@ -135,6 +114,15 @@ EXAMPLES = """
       region: "eu-west-1"
       bucket: "some-bucket"
       key: "random.tfstate"
+
+- name: Define the backend configuration with one or more files at init
+  terraform:
+    project_path: 'project/'
+    state: "{{ state }}"
+    force_init: true
+    backend_config_files:
+      - /path/to/backend_config_file_1
+      - /path/to/backend_config_file_2
 """
 
 RETURN = """
@@ -170,7 +158,6 @@ command:
 import os
 import json
 import tempfile
-import time
 import traceback
 from ansible.module_utils.six.moves import shlex_quote
 
@@ -181,7 +168,7 @@ APPLY_ARGS = ('apply', '-no-color', '-input=false', '-auto-approve=true')
 module = None
 
 
-def preflight_validation(module, bin_path, project_path, variables_args=None, plan_file=None):
+def preflight_validation(bin_path, project_path, variables_args=None, plan_file=None):
     if project_path in [None, ''] or '/' not in project_path:
         module.fail_json(msg="Path for Terraform project can not be None or ''.")
     if not os.path.exists(bin_path):
@@ -194,15 +181,15 @@ def preflight_validation(module, bin_path, project_path, variables_args=None, pl
         module.fail_json(msg="Failed to validate Terraform configuration files:\r\n{0}".format(err))
 
 
-def _state_args(module, state_file):
+def _state_args(state_file):
     if state_file and os.path.exists(state_file):
         return ['-state', state_file]
-    elif state_file and not os.path.exists(state_file):
+    if state_file and not os.path.exists(state_file):
         module.fail_json(msg='Could not find state_file "{0}", check the path and try again.'.format(state_file))
     return []
 
 
-def init_plugins(bin_path, project_path, backend_config):
+def init_plugins(bin_path, project_path, backend_config, backend_config_files):
     command = [bin_path, 'init', '-input=false']
     if backend_config:
         for key, val in backend_config.items():
@@ -210,12 +197,15 @@ def init_plugins(bin_path, project_path, backend_config):
                 '-backend-config',
                 shlex_quote('{0}={1}'.format(key, val))
             ])
+    if backend_config_files:
+        for f in backend_config_files:
+            command.extend(['-backend-config', f])
     rc, out, err = module.run_command(command, cwd=project_path)
     if rc != 0:
         module.fail_json(msg="Failed to initialize Terraform modules:\r\n{0}".format(err))
 
 
-def get_workspace_context(module, bin_path, project_path):
+def get_workspace_context(bin_path, project_path):
     workspace_ctx = {"current": "default", "all": []}
     command = [bin_path, 'workspace', 'list', '-no-color']
     rc, out, err = module.run_command(command, cwd=project_path)
@@ -232,7 +222,7 @@ def get_workspace_context(module, bin_path, project_path):
     return workspace_ctx
 
 
-def _workspace_cmd(module, bin_path, project_path, action, workspace):
+def _workspace_cmd(bin_path, project_path, action, workspace):
     command = [bin_path, 'workspace', action, workspace, '-no-color']
     rc, out, err = module.run_command(command, cwd=project_path)
     if rc != 0:
@@ -241,18 +231,18 @@ def _workspace_cmd(module, bin_path, project_path, action, workspace):
 
 
 def create_workspace(bin_path, project_path, workspace):
-    _workspace_cmd(module, bin_path, project_path, 'new', workspace)
+    _workspace_cmd(bin_path, project_path, 'new', workspace)
 
 
 def select_workspace(bin_path, project_path, workspace):
-    _workspace_cmd(module, bin_path, project_path, 'select', workspace)
+    _workspace_cmd(bin_path, project_path, 'select', workspace)
 
 
 def remove_workspace(bin_path, project_path, workspace):
-    _workspace_cmd(module, bin_path, project_path, 'delete', workspace)
+    _workspace_cmd(bin_path, project_path, 'delete', workspace)
 
 
-def build_plan(module, command, project_path, variables_args, state_file, targets, state, plan_path=None):
+def build_plan(command, project_path, variables_args, state_file, targets, state, plan_path=None):
     if plan_path is None:
         f, plan_path = tempfile.mkstemp(suffix='.tfplan')
 
@@ -261,7 +251,7 @@ def build_plan(module, command, project_path, variables_args, state_file, target
     for t in (module.params.get('targets') or []):
         plan_command.extend(['-target', t])
 
-    plan_command.extend(_state_args(module, state_file))
+    plan_command.extend(_state_args(state_file))
 
     rc, out, err = module.run_command(plan_command + variables_args, cwd=project_path, use_unsafe_shell=True)
 
@@ -278,114 +268,17 @@ def build_plan(module, command, project_path, variables_args, state_file, target
     module.fail_json(msg='Terraform plan failed with unexpected exit code {0}. \r\nSTDOUT: {1}\r\n\r\nSTDERR: {2}'.format(rc, out, err))
 
 
-def return_full_path(log_activity_folder, file_name):
-    if log_activity_folder[-1] != '/':
-        full_path = log_activity_folder + '/' + file_name + '.json'
-    else:
-        full_path = log_activity_folder + file_name + '.json'
-
-    return full_path
-
-
-def create_logging_file_and_directory(log_activity_folder, file_name):
-    full_path = return_full_path(log_activity_folder, file_name)
-    if not os.path.exists(log_activity_folder):
-        os.makedirs(log_activity_folder)
-
-    if not os.path.exists(full_path):
-        with open(full_path, 'w') as file_created:
-            json.dump([], file_created, indent=4)
-
-
-def logging(log_activity_folder, file_name, plan_used, command_run, stdout):
-    path_to_audit_file = return_full_path(log_activity_folder, file_name)
-    timestamp = time.strftime('%d-%m-%Y %H:%M:%S')
-    command_used = command_run[1]
-    outcome = ''
-    list_destruction = []
-    list_creation = []
-    list_modification = []
-    if command_used == "apply" or command_used == "destroy":
-        for line in stdout.split('\n'):
-            if line.startswith('Apply complete!') or line.startswith('No changes') or line.startswith('Destroy complete!'):
-                outcome = line
-                break
-            else:
-                try:
-                    if line.split(':')[1].startswith(" Destruction"):
-                        list_destruction.append(line.split(':')[0])
-                    if line.split(':')[1].startswith(" Creation"):
-                        list_creation.append(line.split(':')[0])
-                    if line.split(':')[1].startswith(" Modification"):
-                        list_modification.append(line.split(':')[0])
-                except IndexError:
-                    pass
-    elif command_used == "plan":
-        for line in stdout.split('\n'):
-            if line.startswith('Plan:') or line.startswith('No changes'):
-                outcome = line
-    items_to_write = {
-        'time': timestamp,
-        'plan_used': plan_used,
-        'command_run': command_used,
-        'outcome': outcome,
-        'resources_added': list_creation,
-        'resources_changed': list_modification,
-        'resources_destroyed': list_destruction}
-
-    with open(path_to_audit_file, 'r') as file_opened:
-        data_stored = json.load(file_opened)
-
-    data_stored.append(items_to_write)
-
-    with open(path_to_audit_file, 'w') as file_opened:
-        json.dump(data_stored, file_opened, indent=4)
-
-
-def get_plan_file_name_without_extension(plan_file_path):
-    file_name, extension = os.path.basename(plan_file_path).split(".")
-    return file_name
-
-
-def get_plans_used(log_activity_folder, file_name):
-    log_activity_path = return_full_path(log_activity_folder, file_name)
-    plans = []
-    with open(log_activity_path, 'r') as file_opened:
-        data_stored = json.load(file_opened)
-    for record in data_stored:
-        if 'plan' in record.values():
-            plans.append(record)
-    return plans
-
-
-def get_plan_file_from_logging_file(log_activity_folder, file_name, plan_id):
-    log_activity_path = return_full_path(log_activity_folder, full_name)
-    all_entries_with_file = []
-    search_file_path = '/tmp/{0}.tfplan'.format(plan_id)
-    for i in get_plans_used(log_activity_folder, file_name):
-        if search_file_path in i.values():
-            all_entries_with_file.append(i)
-    if all_entries_with_file:
-        return all_entries_with_file[0]['plan_used']
-    else:
-        return ''
-
-
 def main():
-    message = ""
     global module
     module = AnsibleModule(
         argument_spec=dict(
             project_path=dict(required=True, type='path'),
-            plan_id=dict(type='str'),
-            log_activity_folder=dict(type='path'),
-            file_name=dict(type='str'),
             binary_path=dict(type='path'),
             workspace=dict(required=False, type='str', default='default'),
             purge_workspace=dict(type='bool', default=False),
             state=dict(default='present', choices=['present', 'absent', 'planned']),
             variables=dict(type='dict'),
-            variables_file=dict(type='path'),
+            variables_files=dict(aliases=['variables_file'], type='list', elements='path', default=None),
             plan_file=dict(type='path'),
             state_file=dict(type='path'),
             targets=dict(type='list', default=[]),
@@ -393,7 +286,9 @@ def main():
             lock_timeout=dict(type='int',),
             force_init=dict(type='bool', default=False),
             backend_config=dict(type='dict', default=None),
+            backend_config_files=dict(type='list', elements='path', default=None),
         ),
+        required_if=[('state', 'planned', ['plan_file'])],
         supports_check_mode=True,
     )
 
@@ -403,20 +298,12 @@ def main():
     purge_workspace = module.params.get('purge_workspace')
     state = module.params.get('state')
     variables = module.params.get('variables') or {}
-    variables_file = module.params.get('variables_file')
+    variables_files = module.params.get('variables_files')
     plan_file = module.params.get('plan_file')
     state_file = module.params.get('state_file')
     force_init = module.params.get('force_init')
     backend_config = module.params.get('backend_config')
-    plan_id = module.params.get('plan_id')
-    log_activity_folder = module.params.get('log_activity_folder')
-    file_name = module.params.get('file_name')
-
-    if not log_activity_folder:
-        log_activity_folder = './'
-
-    if not file_name:
-        file_name = 'audit'
+    backend_config_files = module.params.get('backend_config_files')
 
     if bin_path is not None:
         command = [bin_path]
@@ -424,9 +311,9 @@ def main():
         command = [module.get_bin_path('terraform', required=True)]
 
     if force_init:
-        init_plugins(command[0], project_path, backend_config)
+        init_plugins(command[0], project_path, backend_config, backend_config_files)
 
-    workspace_ctx = get_workspace_context(module, command[0], project_path)
+    workspace_ctx = get_workspace_context(command[0], project_path)
     if workspace_ctx["current"] != workspace:
         if workspace not in workspace_ctx["all"]:
             create_workspace(command[0], project_path, workspace)
@@ -444,10 +331,11 @@ def main():
             '-var',
             '{0}={1}'.format(k, v)
         ])
-    if variables_file:
-        variables_args.extend(['-var-file', variables_file])
+    if variables_files:
+        for f in variables_files:
+            variables_args.extend(['-var-file', f])
 
-    preflight_validation(module, command[0], project_path, variables_args)
+    preflight_validation(command[0], project_path, variables_args)
 
     if module.params.get('lock') is not None:
         if module.params.get('lock'):
@@ -465,8 +353,6 @@ def main():
 
     out, err = '', ''
 
-    create_logging_file_and_directory(log_activity_folder, file_name)
-
     if state == 'absent':
         command.extend(variables_args)
     elif state == 'present' and plan_file:
@@ -474,34 +360,10 @@ def main():
             command.append(plan_file)
         else:
             module.fail_json(msg='Could not find plan_file "{0}", check the path and try again.'.format(plan_file))
-    elif state == 'present' and plan_id:
-        plan_file = get_plan_file_from_logging_file(log_activity_folder, file_name, plan_id)
-        if plan_file:
-            command.append(plan_file)
-            message = "running apply with plan_id: {0}".format(plan_id)
-        else:
-            module.fail_json(msg="plan file with id does not exist!")
-    elif state == 'present' and not plan_id:
-        last_plan_used = get_plans_used(log_activity_folder, file_name)
-        if last_plan_used:
-            message = "no plan file specified. running 'apply' with plan created from recently run 'plan' \
-            command with id: {}".format(get_plan_file_name_without_extension(last_plan_used[-1]['plan_used']))
-            command.append(last_plan_used[-1]['plan_used'])
-            plan_file = last_plan_used[-1]['plan_used']
-        else:
-            # no plan command run yet
-            plan_file, needs_application, out, err, command = build_plan(
-                module, command, project_path,
-                variables_args, state_file, module.params.get('targets'), state, plan_file)
-            command.append(plan_file)
-            message = "running apply without having run plan before"
-
     else:
-        plan_file, needs_application, out, err, command = build_plan(
-                                                        module, command, project_path,
-                                                        variables_args, state_file, module.params.get('targets'), state, plan_file)
+        plan_file, needs_application, out, err, command = build_plan(command, project_path, variables_args, state_file,
+                                                                     module.params.get('targets'), state, plan_file)
         command.append(plan_file)
-        message = "plan command executed. plan_id generated: {0}".format(get_plan_file_name_without_extension(plan_file))
 
     if needs_application and not module.check_mode and not state == 'planned':
         rc, out, err = module.run_command(command, cwd=project_path)
@@ -514,7 +376,7 @@ def main():
                 command=' '.join(command)
             )
 
-    outputs_command = [command[0], 'output', '-no-color', '-json'] + _state_args(module, state_file)
+    outputs_command = [command[0], 'output', '-no-color', '-json'] + _state_args(state_file)
     rc, outputs_text, outputs_err = module.run_command(outputs_command, cwd=project_path)
     if rc == 1:
         module.warn("Could not get Terraform outputs. This usually means none have been defined.\nstdout: {0}\nstderr: {1}".format(outputs_text, outputs_err))
@@ -533,9 +395,7 @@ def main():
     if state == 'absent' and workspace != 'default' and purge_workspace is True:
         remove_workspace(command[0], project_path, workspace)
 
-    logging(log_activity_folder, file_name, plan_file, command, out)
-
-    module.exit_json(changed=changed, message=message, state=state, workspace=workspace, outputs=outputs, stdout=out, stderr=err, command=' '.join(command))
+    module.exit_json(changed=changed, state=state, workspace=workspace, outputs=outputs, stdout=out, stderr=err, command=' '.join(command))
 
 
 if __name__ == '__main__':

--- a/tests/unit/plugins/modules/cloud/misc/test_terraform.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_terraform.py
@@ -1,11 +1,7 @@
 import json
-
 import pytest
-
 import sys
-
 from ansible_collections.community.general.plugins.modules.cloud.misc import terraform
-
 import mock
 import os
 
@@ -13,11 +9,9 @@ from ansible.module_utils._text import to_bytes
 from ansible.module_utils import basic
 
 
-
 def set_module_args(args):
-    args = json.dumps({'ANSIBLE_MODULE_ARGS':args})
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
     basic._ANSIBLE_ARGS = to_bytes(args)
-
 
 
 class AnsibleExitJson(Exception):
@@ -31,7 +25,6 @@ class AnsibleFailJson(Exception):
 def fail_json(*args, **kwargs):
     kwargs['failed'] = True
     raise AnsibleFailJson(kwargs)
-    
 
 
 def exit_json(*args, **kwargs):
@@ -48,6 +41,7 @@ def test_state_args():
         terraform._state_args(module, '/rrrr')
     module.fail_json.assert_called()
 
+
 def test_returned_value_state_args(tmpdir):
     test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
     test_file = test_temp_folder_for_project_path.join("test_file.txt")
@@ -62,20 +56,20 @@ def test_return_empty_list_state_args():
     module.fail_json.side_effect = AnsibleFailJson(Exception)
     value = terraform._state_args(module, '')
     assert value == []
-    
+
 
 def test_fail_json_preflight_validation_with_project_path_not_provided():
     module = mock.MagicMock()
     module.fail_json.side_effect = AnsibleFailJson(Exception)
     with pytest.raises(AnsibleFailJson):
-        terraform.preflight_validation(module,'', '/rri')
+        terraform.preflight_validation(module, '', '/rri')
 
     module.fail_json.assert_called()
-    
+
 
 def test_preflight_validation_with_arguments_satisfied_but_with_error_code_returned(tmpdir):
     test_project_path = tmpdir.mkdir("project-path")
-    test_file = test_project_path.join("test_file.tfplan")
+    test_file = test_project_path.join("test_file.txt")
     module = mock.MagicMock()
     module.fail_json.side_effect = AnsibleFailJson(Exception)
     module.run_command = mock.MagicMock()
@@ -84,9 +78,10 @@ def test_preflight_validation_with_arguments_satisfied_but_with_error_code_retur
         terraform.preflight_validation(module, '/', test_file.dirname, [''])
     module.fail_json.assert_called()
 
+
 def test_preflight_validation_with_arguments_satisfied_without_error_code(tmpdir):
     test_project_path = tmpdir.mkdir("project-path")
-    test_file = test_project_path.join("test_file.tfplan")
+    test_file = test_project_path.join("test_file.txt")
     module = mock.MagicMock()
     module.fail_json.side_effect = AnsibleFailJson(Exception)
     module.run_command = mock.MagicMock()
@@ -95,9 +90,10 @@ def test_preflight_validation_with_arguments_satisfied_without_error_code(tmpdir
 
     module.fail_json.assert_not_called()
 
+
 def test_get_workspace_context(tmpdir):
     test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
-    test_file = test_temp_folder_for_project_path.join("test_file.tfplan")
+    test_file = test_temp_folder_for_project_path.join("test_file.txt")
     module = mock.MagicMock()
     module.run_command = mock.MagicMock()
     out = '''
@@ -120,8 +116,8 @@ def test_build_plan_with_state_planned(tmpdir):
     module.run_command.return_value = (0, '', '')
     returned_tuple_results = terraform.build_plan(module, [test_file.dirname], test_file.dirname, [], '', [], 'planned', full_path)
     print(returned_tuple_results)
-    assert returned_tuple_results == (full_path, False, '', '', [test_file.dirname, 'plan', '-input=false', '-no-color', '-detailed-exitcode','-out',full_path])
-    
+    assert returned_tuple_results == (full_path, False, '', '', [test_file.dirname, 'plan', '-input=false', '-no-color', '-detailed-exitcode', '-out', full_path])
+
 
 def test_build_plan_with_state_not_planned_and_return_code_zero(tmpdir):
     test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
@@ -132,6 +128,7 @@ def test_build_plan_with_state_not_planned_and_return_code_zero(tmpdir):
     module.run_command.return_value = (0, '', '')
     returned_tuple_results = terraform.build_plan(module, [test_file.dirname], test_file.dirname, [], '', [], 'present', full_path)
     assert returned_tuple_results == (full_path, False, '', '', [test_file.dirname])
+
 
 def test_build_plan_with_state_planned_with_returned_code_one(tmpdir):
     test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
@@ -145,6 +142,7 @@ def test_build_plan_with_state_planned_with_returned_code_one(tmpdir):
         returned_tuple_results = terraform.build_plan(module, [test_file.dirname], test_file.dirname, [], '', [], 'planned', full_path)
     module.fail_json.assert_called()
 
+
 def test_build_plan_with_state_planned_with_return_code_two(tmpdir):
     test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
     test_file = test_temp_folder_for_project_path.join("test_file.tfplan")
@@ -153,7 +151,9 @@ def test_build_plan_with_state_planned_with_return_code_two(tmpdir):
     module.run_command = mock.MagicMock()
     module.run_command.return_value = (2, '', '')
     returned_tuple_results = terraform.build_plan(module, [test_file.dirname], test_file.dirname, [], '', [], 'planned', full_path)
-    assert returned_tuple_results == (full_path, True, '', '', [test_file.dirname, 'plan', '-input=false', '-no-color', '-detailed-exitcode', '-out', full_path])
+    assert returned_tuple_results == (full_path, True, '', '', [test_file.dirname, 'plan', '-input=false', '-no-color',
+                                                                '-detailed-exitcode', '-out', full_path])
+
 
 def test_build_plan_with_state_not_planned_with_return_code_two(tmpdir):
     test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
@@ -164,6 +164,7 @@ def test_build_plan_with_state_not_planned_with_return_code_two(tmpdir):
     module.run_command.return_value = (2, '', '')
     returned_tuple_results = terraform.build_plan(module, [test_file.dirname], test_file.dirname, [], '', [], 'absent', full_path)
     assert returned_tuple_results == (full_path, True, '', '', [test_file.dirname])
+
 
 def test_build_plan_with_return_code_greater_than_two(tmpdir):
     test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
@@ -193,4 +194,3 @@ def test_terraform_without_argument(capfd):
     assert not err
     assert json.loads(out)['failed']
     assert 'project_path' in json.loads(out)['msg']
-

--- a/tests/unit/plugins/modules/cloud/misc/test_terraform.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_terraform.py
@@ -1,12 +1,85 @@
-# Copyright: (c) 2019, Ansible Project
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
 import json
 
 import pytest
 
+import sys
+
 from ansible_collections.community.general.plugins.modules.cloud.misc import terraform
-from ansible_collections.community.general.tests.unit.plugins.modules.utils import set_module_args
+import terraform
+
+import mock
+import os
+
+from ansible.module_utils._text import to_bytes
+from ansible.module_utils import basic
+
+
+def set_module_args(args):
+    args = json.dumps({'ANSIBLE_MODULE_ARGS':args})
+    basic._ANSIBLE_ARGS = to_bytes(args)
+
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def fail_json(*args, **kwargs):
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+    
+
+
+def exit_json(*args, **kwargs):
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+
+    raise AnsibleExitJson(kwargs)
+
+
+module = mock.MagicMock()
+module.fail_json.side_effect = AnsibleFailJson(Exception)
+module.exit_json.side_effect = AnsibleExitJson(Exception)
+
+def test_state_args():
+    with pytest.raises(AnsibleFailJson):
+        terraform._state_args(module, '/rrrr')
+    module.fail_json.assert_called()
+
+def test_returned_value_state_args():
+    value = terraform._state_args(module, '/vagrant')
+    assert value == ['-state', '/vagrant']
+
+def test_return_empty_list_state_args():
+    value = terraform._state_args(module, '')
+    assert value == []
+    
+
+def test_fail_json_preflight_validation_with_project_path_not_provided():
+    with pytest.raises(AnsibleFailJson):
+        terraform.preflight_validation(module,'', '/rri')
+    print(module.fail_json.msg)
+
+    module.fail_json.assert_called()
+    
+
+def test_preflight_validation_with_arguments_satisfied():
+    set_module_args({
+        'project_path':'/vagrant',
+        'bin_path':'/vagrant',
+        })
+    module.patch.object(basic.AnsibleModule, 'run_command', return_values=(0, '', ''))
+    module.run_command('/usr/bin/command args')
+    #with mock.patch.object(basic.AnsibleModule, 'run_command') as run_command:
+       # run_command.return_value = 0, '', ''
+        #with pytest.raises(AnsibleExitJson) as result:
+            #terraform.preflight_validation(module, '/vagrant', '/vagrant', ['yy','see'])
+    module.main()
+    module.run_command.assert_called_once_with('/usr/bin/command args')
 
 
 def test_terraform_without_argument(capfd):
@@ -18,3 +91,4 @@ def test_terraform_without_argument(capfd):
     assert not err
     assert json.loads(out)['failed']
     assert 'project_path' in json.loads(out)['msg']
+


### PR DESCRIPTION
##### SUMMARY
Added the functionality to log activities (example performing a terraform apply, run or destroy, outcomes(number of resources added or destroyed or changed)) in a json format into an audit file.

format:
`  {
         'time': timestamp,
         'plan_used': plan_used,
         'command_run': command_used,
         'outcome': outcome,
         'resources_added': list_creation,
         'resources_changed': list_modification,
         'resources_destroyed': list_destruction
         }`

The current module creates a temporary plan files every time you run the 'apply' command or a 'plan' command  if you do not provide a path to a plan_file. 

The contents of the audit file helps to retrieve the path to last plan file generated automatically by the module when the 'plan' command was run so that the user has the option to reuse the plan file generated by providing an id that would be displayed to the user upon running the 'plan' command without providing a path to the plan file.

Also added test cases for some already existing functions in the module.

Fixes to [#5 ](https://github.com/turntabl/community.general/issues/5) and [#3](https://github.com/turntabl/community.general/issues/3)

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
terraform module

##### ADDITIONAL INFORMATION

The model currently takes additional parameters `plan_id` provided by the user in case they might wish to reuse a plan file, `log_activity_folder`  path to a folder to containing the file to log the activities as stated earlier, and `file_name` to create the audit file and name the file with. 

If the user does not provide the `plan_id` and a `plan_path` and he or she performs a plan before an apply, the module retrieves the path to the last plan file generated by the user from the audit file and uses that plan file.
 
The already existing functions in the module did not have test cases so a few test cases have been added.

example:

playbook.yml:
```
- name: terraform 
    terraform:
      project_path: '/tmp/project/'
      plan_id: 'tmpER44'
      log_activity_folder: '/home/user/'
      file_name: 'jnnj4444'
      state: present
      check_deletes: True

```

when this playbook is executed it will create a file named `jnnj4444` in the `/home/user/` directory.
contents of `jnnj4444`:
`
[
    {
        "plan_used": "/tmp/tmpER44.tfplan",
        "resources_added": [],
        "resources_destroyed": [],
        "time": "21-05-2020 23:51:08",
        "command_run": "apply",
        "outcome": "Apply complete! Resources: 0 added, 0 changed, 0 destroyed."   
        "resources_changed": []
     }
]
`
