### PR TITLE
State queries

### DIFF
--- a/plugins/lookup/terraform.py
+++ b/plugins/lookup/terraform.py
@@ -29,14 +29,14 @@ options:
 '''
 
 EXAMPLES = '''
-- debug: msg="the value of foo.txt is {{ lookup('terraform',
-    resource_type='aws_ec2_instance', state_file='mydir/foo.txt', resource_name='project-name') }}"
+- debug: msg="the ID is {{ lookup('terraform',
+    resource_type='aws_lb', state_file='mydir/foo.txt', resource_name='foo') }}"
 '''
 
 RETURN = '''
 _raw:
     description:
-        - information about resources which match search
+        - IDs about resources which match lookup
 '''
 
 

--- a/plugins/lookup/terraform.py
+++ b/plugins/lookup/terraform.py
@@ -51,19 +51,22 @@ try:
     HAS_LIB = True
 except ImportError:
     HAS_LIB = False
+def json_query(data, expr):
+
+  '''Query json data using jmespath query language ( http://jmespath.org )'''
+  if not HAS_LIB:
+
+    raise AnsibleError('You need to install "jmespath" to run this plugin')
+  try:
+    return jmespath.search(expr, data)
+  except jmespath.exceptions.JMESPathError as e:
+    raise AnsibleError('JMESPathError in json_query lookup plugin:\n%s' % to_native(e))
+  except Exception as e:
+    raise AnsibleError('Error in jmespath.search in json_query lookup plugin:\n%s' % to_native(e))
+
 
 class LookupModule(LookupBase):
 
-  def json_query(self, data, expr):
-    '''Query json data using jmespath query language ( http://jmespath.org )'''
-    if not HAS_LIB:
-        raise AnsibleError('You need to install "jmespath" to run this plugin')
-    try:
-        return jmespath.search(expr, data)
-    except jmespath.exceptions.JMESPathError as e:
-        raise AnsibleError('JMESPathError in json_query lookup plugin:\n%s' % to_native(e))
-    except Exception as e:
-        raise AnsibleError('Error in jmespath.search in json_query lookup plugin:\n%s' % to_native(e))
 
   def run(self, terms, variables=None, **kwargs):
 
@@ -90,7 +93,7 @@ class LookupModule(LookupBase):
         if resource_type is not None and resource_name is not None:
           query = "((resources[?type == '{resource_type}'].instances[].attributes.id) && (resources[?name == '{resource_name}'].instances[].attributes.id))".format(resource_type=resource_type, resource_name=resource_name)
           
-        returned_data.append(self.json_query(data, query))  
+        returned_data.append(json_query(data, query))  
 
     except AnsibleError:
       raise AnsibleError('File not found in %s' % state_file)

--- a/plugins/lookup/terraform.py
+++ b/plugins/lookup/terraform.py
@@ -41,8 +41,8 @@ _raw:
 
 
 from ansible.plugins.lookup import LookupBase
-from ansible.module_utils._text import to_native, to_text
-from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.module_utils._text import to_native
+from ansible.errors import AnsibleError
 import json
 
 
@@ -51,51 +51,50 @@ try:
     HAS_LIB = True
 except ImportError:
     HAS_LIB = False
+
+
 def json_query(data, expr):
 
-  '''Query json data using jmespath query language ( http://jmespath.org )'''
-  if not HAS_LIB:
-
-    raise AnsibleError('You need to install "jmespath" to run this plugin')
-  try:
-    return jmespath.search(expr, data)
-  except jmespath.exceptions.JMESPathError as e:
-    raise AnsibleError('JMESPathError in json_query lookup plugin:\n%s' % to_native(e))
-  except Exception as e:
-    raise AnsibleError('Error in jmespath.search in json_query lookup plugin:\n%s' % to_native(e))
+    '''Query json data using jmespath query language ( http://jmespath.org )'''
+    if not HAS_LIB:
+        raise AnsibleError('You need to install "jmespath" to run this plugin')
+    try:
+        return jmespath.search(expr, data)
+    except jmespath.exceptions.JMESPathError as e:
+        raise AnsibleError('JMESPathError in json_query lookup plugin:\n%s' % to_native(e))
+    except Exception as e:
+        raise AnsibleError('Error in jmespath.search in json_query lookup plugin:\n%s' % to_native(e))
 
 
 class LookupModule(LookupBase):
 
+    def run(self, terms, variables=None, **kwargs):
 
-  def run(self, terms, variables=None, **kwargs):
+        returned_data = []
 
-    returned_data = []
+        state_file = kwargs.get('state_file')
+        resource_type = kwargs.get('resource_type', None)
+        resource_name = kwargs.get('resource_name', None)
 
-    state_file = kwargs.get('state_file')
-    resource_type = kwargs.get('resource_type', None)
-    resource_name = kwargs.get('resource_name', None)
-    
-    lookupfile = self.find_file_in_search_path(variables, 'files', state_file)
+        lookupfile = self.find_file_in_search_path(variables, 'files', state_file)
 
-    try:
-      if lookupfile: 
+        try:
+            if lookupfile:
+                content, show_data = self._loader._get_file_contents(lookupfile)
+                data = json.loads(content)
+                query = ""
+                if not resource_type and not resource_name:
+                    raise AnsibleError("Pass at least one of the options 'resource_type' or 'resource_name'")
+                if resource_type is not None and resource_name is None:
+                    query = "resources[?type == '{resource_type}'].instances[].attributes.id".format(resource_type=resource_type)
+                if resource_type is None and resource_name is not None:
+                    query = "resources[?name == '{resource_name}'].instances[].attributes.id".format(resource_name=resource_name)
+                if resource_type is not None and resource_name is not None:
+                    query = ("((resources[?type == '{resource_type}'].instances[].attributes.id)"
+                             " && (resources[?name == '{resource_name}'].instances[]."
+                             "attributes.id))".format(resource_type=resource_type, resource_name=resource_name))
 
-        content, show_data = self._loader._get_file_contents(lookupfile)
-        data = json.loads(content)
-        query = ""
-        if not resource_type and not resource_name:
-          raise AnsibleError("Pass at least one of the options 'resource_type' or 'resource_name'")
-        if resource_type is not None and resource_name is None:
-          query = "resources[?type == '{resource_type}'].instances[].attributes.id".format(resource_type=resource_type)
-        if resource_type is None and resource_name is not None:
-          query = "resources[?name == '{resource_name}'].instances[].attributes.id".format(resource_name=resource_name)
-        if resource_type is not None and resource_name is not None:
-          query = "((resources[?type == '{resource_type}'].instances[].attributes.id) && (resources[?name == '{resource_name}'].instances[].attributes.id))".format(resource_type=resource_type, resource_name=resource_name)
-          
-        returned_data.append(json_query(data, query))  
-
-    except AnsibleError:
-      raise AnsibleError('File not found in %s' % state_file)
-
-    return returned_data
+                returned_data.append(json_query(data, query))
+        except AnsibleError:
+            raise AnsibleError('File not found in %s' % state_file)
+        return returned_data

--- a/plugins/lookup/terraform.py
+++ b/plugins/lookup/terraform.py
@@ -1,0 +1,98 @@
+# (c) 2020, Turntabl GH <info(at)turntabl.io>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+lookup: terraform
+description:
+  - This lookup returns the ids of resources from state plan files
+short_description: Return resource ids from terraform statefiles by passing either the resource type or resource name or both
+author: Turntabl GH <info@turntabl.io>
+requirements:
+  - jmespath
+options:
+  state_file:
+    description:
+      - The path to the statefile.
+    required: true
+  resource_type:
+    description:
+      - The terraform resource type.
+    required: false
+  resource_name:
+    description:
+      - The terraform resource name.
+    required: false
+'''
+
+EXAMPLES = '''
+- debug: msg="the value of foo.txt is {{ lookup('terraform',
+    resource_type='aws_ec2_instance', state_file='mydir/foo.txt', resource_name='project-name') }}"
+'''
+
+RETURN = '''
+_raw:
+    description:
+        - information about resources which match search
+'''
+
+
+from ansible.plugins.lookup import LookupBase
+from ansible.module_utils._text import to_native, to_text
+from ansible.errors import AnsibleError, AnsibleParserError
+import json
+
+
+try:
+    import jmespath
+    HAS_LIB = True
+except ImportError:
+    HAS_LIB = False
+
+class LookupModule(LookupBase):
+
+  def json_query(self, data, expr):
+    '''Query json data using jmespath query language ( http://jmespath.org )'''
+    if not HAS_LIB:
+        raise AnsibleError('You need to install "jmespath" to run this plugin')
+    try:
+        return jmespath.search(expr, data)
+    except jmespath.exceptions.JMESPathError as e:
+        raise AnsibleError('JMESPathError in json_query lookup plugin:\n%s' % to_native(e))
+    except Exception as e:
+        raise AnsibleError('Error in jmespath.search in json_query lookup plugin:\n%s' % to_native(e))
+
+  def run(self, terms, variables=None, **kwargs):
+
+    returned_data = []
+
+    state_file = kwargs.get('state_file')
+    resource_type = kwargs.get('resource_type', None)
+    resource_name = kwargs.get('resource_name', None)
+    
+    lookupfile = self.find_file_in_search_path(variables, 'files', state_file)
+
+    try:
+      if lookupfile: 
+
+        content, show_data = self._loader._get_file_contents(lookupfile)
+        data = json.loads(content)
+        query = ""
+        if not resource_type and not resource_name:
+          raise AnsibleError("Pass at least one of the options 'resource_type' or 'resource_name'")
+        if resource_type is not None and resource_name is None:
+          query = "resources[?type == '{resource_type}'].instances[].attributes.id".format(resource_type=resource_type)
+        if resource_type is None and resource_name is not None:
+          query = "resources[?name == '{resource_name}'].instances[].attributes.id".format(resource_name=resource_name)
+        if resource_type is not None and resource_name is not None:
+          query = "((resources[?type == '{resource_type}'].instances[].attributes.id) && (resources[?name == '{resource_name}'].instances[].attributes.id))".format(resource_type=resource_type, resource_name=resource_name)
+          
+        returned_data.append(self.json_query(data, query))  
+
+    except AnsibleError:
+      raise AnsibleError('File not found in %s' % state_file)
+
+    return returned_data

--- a/tests/unit/plugins/lookup/test_terraform.py
+++ b/tests/unit/plugins/lookup/test_terraform.py
@@ -1,0 +1,76 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+import pytest
+from ansible_collections.community.general.plugins.lookup.terraform import json_query
+import json
+MOCKED_DATA = '''{
+            "version": 18,
+            "terraform_version": "0.12.20",
+            "serial": 174,
+            "lineage": "4112ahd23-925z-4e9a-1ce3-6026649c1ef7",
+            "outputs": {},
+            "resources" : [
+          {
+            "module": "module.sample-module",
+            "mode": "data",
+            "type": "aws_acm_certificate",
+            "name": "my-sample-certificate",
+            "provider": "provider.aws",
+            "instances": [
+                {
+                "schema_version": 0,
+                "attributes": {
+                    "arn": "arn:aws:acm:eu-west-2:12345678:certificate/01986237-8735-40b9-bd0d-954c674f454c",
+                    "domain": "example.com",
+                    "id": "2020-05-26 19:22:40.6699801 +0000 UTC",
+                    "key_types": null,
+                    "most_recent": true,
+                    "statuses": null,
+                    "types": [
+                      "AMAZON_ISSUED"
+                    ]
+                }
+                }
+            ]
+    },
+                 {
+            "mode": "managed",
+            "type": "aws_iam_role_policy",
+            "name": "s3-access-policy",
+            "provider": "provider.aws",
+            "instances": [
+              {
+                "schema_version": 0,
+                "attributes": {
+                  "id": "access-role:s3-access",
+                  "name": "s3-access",
+                  "name_prefix": null,
+                  "role": "sample-role"
+                },
+                "private": "bnVsbA=="
+              }
+            ]
+          }
+            ]
+            }
+'''
+
+class TestTerraformLookup:
+
+    @pytest.fixture(scope="module")
+    def convert_mocked_data(self):
+        yield json.loads(MOCKED_DATA)
+
+    def test_terraform_version_number(self, convert_mocked_data):
+        assert json_query(convert_mocked_data, "terraform_version") == "0.12.20"
+
+        
+    def test_sample_certificate_name(self, convert_mocked_data):
+        assert json_query(convert_mocked_data,"resources[?module == 'module.sample-module'].name") == ["my-sample-certificate"]
+
+    
+    def test_schema_version(self, convert_mocked_data):
+        assert json_query(convert_mocked_data, "resources[?instances[?attributes.name == 's3-access']].instances[].attributes.name") == ['s3-access']
+

--- a/tests/unit/plugins/lookup/test_terraform.py
+++ b/tests/unit/plugins/lookup/test_terraform.py
@@ -57,6 +57,7 @@ MOCKED_DATA = '''{
             }
 '''
 
+
 class TestTerraformLookup:
 
     @pytest.fixture(scope="module")
@@ -66,11 +67,8 @@ class TestTerraformLookup:
     def test_terraform_version_number(self, convert_mocked_data):
         assert json_query(convert_mocked_data, "terraform_version") == "0.12.20"
 
-        
     def test_sample_certificate_name(self, convert_mocked_data):
-        assert json_query(convert_mocked_data,"resources[?module == 'module.sample-module'].name") == ["my-sample-certificate"]
+        assert json_query(convert_mocked_data, "resources[?module == 'module.sample-module'].name") == ["my-sample-certificate"]
 
-    
     def test_schema_version(self, convert_mocked_data):
         assert json_query(convert_mocked_data, "resources[?instances[?attributes.name == 's3-access']].instances[].attributes.name") == ['s3-access']
-


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently terraform doesnt allow some resource manipulations outside of it. But such manipulations will be convenient to use by other ansible code. A lookup plugin to pull the resource IDS generated by terraform will be useful to do that.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
A fix to https://github.com/turntabl/community.general/issues/2

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
terraform lookup plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The lookup plugin would take the path to the terraform state file and the either the resource type or resource name or both and return the IDS for the matched parameters passed. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- hosts: localhost
  vars:
    content: "{{ lookup('terraform', resource_name='load_balancer', state_file='myproject/terraform.tfstate', resource_type='aws_lb') }}"
  tasks:
   - debug: msg = "The ID is {{ content }}"

```