### PR TITLE
terraform: error-handling

### DIFF
--- a/changelogs/fragments/423-terraform_error_handling.yml
+++ b/changelogs/fragments/423-terraform_error_handling.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+    - terraform module - The current change it useful for user to get all the logs of errors to able to make future decisions with these error messages.
+    - terraform - add the `` log_error_path`` parameter (https://github.com/ansible-collections/community.general/pull/423).

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -32,6 +32,11 @@ options:
       - The path to the root of the Terraform directory with the
         vars.tf/main.tf/etc to use.
     required: true
+  log_error_path:
+    description:
+      - The path to the root of the Terraform directory with the
+        vars.tf/main.tf/etc to use.
+    required: false  
   workspace:
     description:
       - The terraform workspace to work with.
@@ -105,11 +110,13 @@ EXAMPLES = """
 - name: Basic deploy of a service
   terraform:
     project_path: '{{ project_dir }}'
+    log_error_path: '{{ error_dir }}'
     state: present
 
 - name: Define the backend configuration at init
   terraform:
     project_path: 'project/'
+    log_error_path: 'error/'
     state: "{{ state }}"
     force_init: true
     backend_config:
@@ -147,21 +154,27 @@ command:
   returned: always
   sample: terraform apply ...
 """
-
+ 
 import os
 import json
 import tempfile
 import traceback
-from ansible.module_utils.six.moves import shlex_quote
+import time
+import csv
 
+from datetime import datetime
+from io import StringIO
+from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils.basic import AnsibleModule
 
 DESTROY_ARGS = ('destroy', '-no-color', '-force')
 APPLY_ARGS = ('apply', '-no-color', '-input=false', '-auto-approve=true')
 module = None
 
+current_DateTime = datetime.now().strftime("%d/%m/%Y %H:%M:$S")
 
-def preflight_validation(bin_path, project_path, variables_args=None, plan_file=None):
+def preflight_validation(bin_path, project_path, log_error_path, variables_args=None, plan_file=None):   
+    dir_name = log_error_path    
     if project_path in [None, ''] or '/' not in project_path:
         module.fail_json(msg="Path for Terraform project can not be None or ''.")
     if not os.path.exists(bin_path):
@@ -170,17 +183,33 @@ def preflight_validation(bin_path, project_path, variables_args=None, plan_file=
         module.fail_json(msg="Path for Terraform project '{0}' doesn't exist on this host - check the path and try again please.".format(project_path))
 
     rc, out, err = module.run_command([bin_path, 'validate'] + variables_args, cwd=project_path, use_unsafe_shell=True)
-    if rc != 0:
-        module.fail_json(msg="Failed to validate Terraform configuration files:\r\n{0}".format(err))
+    if rc != 0:      
+      with open(dir_name, 'a+', newline='') as file_op:
+        writer = csv.writer(file_op)
+        writer.writerow(StringIO("ERROR RECORDED on "+ current_DateTime + '\r\n' + err))
+      module.fail_json(msg="Failed to validate Terraform configuration files:\r\n{0}".format(err))    
 
 
+def create_error_file_and_directory(log_error_path):
+  error_directory_name, error_file_name = os.path.split(log_error_path)
+  if not os.path.exists(error_directory_name):
+    os.makedirs(error_directory_name)
+  
+  if not os.path.exists(log_error_path):
+    with open(log_error_path, 'w') as file:
+      writer = csv.writer(file, delimiter=',')
+      writer.writerow(StringIO(file))
+
+
+
+      
 def _state_args(state_file):
-    if state_file and os.path.exists(state_file):
-        return ['-state', state_file]
-    if state_file and not os.path.exists(state_file):
-        module.fail_json(msg='Could not find state_file "{0}", check the path and try again.'.format(state_file))
-    return []
-
+      if state_file and os.path.exists(state_file):
+          return ['-state', state_file]
+      if state_file and not os.path.exists(state_file):
+          module.fail_json(msg='Could not find state_file "{0}", check the path and try again.'.format(state_file))
+      return []
+ 
 
 def init_plugins(bin_path, project_path, backend_config):
     command = [bin_path, 'init', '-input=false']
@@ -195,7 +224,7 @@ def init_plugins(bin_path, project_path, backend_config):
         module.fail_json(msg="Failed to initialize Terraform modules:\r\n{0}".format(err))
 
 
-def get_workspace_context(bin_path, project_path):
+def get_workspace_context(bin_path, project_path): 
     workspace_ctx = {"current": "default", "all": []}
     command = [bin_path, 'workspace', 'list', '-no-color']
     rc, out, err = module.run_command(command, cwd=project_path)
@@ -210,6 +239,7 @@ def get_workspace_context(bin_path, project_path):
         else:
             workspace_ctx["all"].append(stripped_item)
     return workspace_ctx
+ 
 
 
 def _workspace_cmd(bin_path, project_path, action, workspace):
@@ -232,7 +262,7 @@ def remove_workspace(bin_path, project_path, workspace):
     _workspace_cmd(bin_path, project_path, 'delete', workspace)
 
 
-def build_plan(command, project_path, variables_args, state_file, targets, state, plan_path=None):
+def build_plan(command, project_path, variables_args, state_file, targets, state, plan_path=None):  
     if plan_path is None:
         f, plan_path = tempfile.mkstemp(suffix='.tfplan')
 
@@ -256,13 +286,14 @@ def build_plan(command, project_path, variables_args, state_file, targets, state
         return plan_path, True, out, err, plan_command if state == 'planned' else command
 
     module.fail_json(msg='Terraform plan failed with unexpected exit code {0}. \r\nSTDOUT: {1}\r\n\r\nSTDERR: {2}'.format(rc, out, err))
-
+  
 
 def main():
     global module
     module = AnsibleModule(
         argument_spec=dict(
             project_path=dict(required=True, type='path'),
+            log_error_path=dict(type='path'),
             binary_path=dict(type='path'),
             workspace=dict(required=False, type='str', default='default'),
             purge_workspace=dict(type='bool', default=False),
@@ -281,6 +312,7 @@ def main():
         supports_check_mode=True,
     )
 
+    log_error_path = module.params.get('log_error_path')
     project_path = module.params.get('project_path')
     bin_path = module.params.get('binary_path')
     workspace = module.params.get('workspace')
@@ -292,6 +324,8 @@ def main():
     state_file = module.params.get('state_file')
     force_init = module.params.get('force_init')
     backend_config = module.params.get('backend_config')
+
+    create_error_file_and_directory(log_error_path)
 
     if bin_path is not None:
         command = [bin_path]
@@ -308,6 +342,7 @@ def main():
         else:
             select_workspace(command[0], project_path, workspace)
 
+    #APPLYING PRESENT AND ABSENT
     if state == 'present':
         command.extend(APPLY_ARGS)
     elif state == 'absent':
@@ -322,8 +357,9 @@ def main():
     if variables_file:
         variables_args.extend(['-var-file', variables_file])
 
-    preflight_validation(command[0], project_path, variables_args)
+    preflight_validation(command[0], project_path,log_error_path, variables_args)
 
+    #LOCK MODULE
     if module.params.get('lock') is not None:
         if module.params.get('lock'):
             command.append('-lock=true')
@@ -339,6 +375,8 @@ def main():
     needs_application, changed = True, False
 
     out, err = '', ''
+
+    
 
     if state == 'absent':
         command.extend(variables_args)

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -36,7 +36,7 @@ options:
     description:
       - The path to the root of the Terraform directory with the
         vars.tf/main.tf/etc to use.
-    required: false  
+    required: false
   workspace:
     description:
       - The terraform workspace to work with.
@@ -154,7 +154,6 @@ command:
   returned: always
   sample: terraform apply ...
 """
- 
 import os
 import json
 import tempfile
@@ -170,11 +169,10 @@ from ansible.module_utils.basic import AnsibleModule
 DESTROY_ARGS = ('destroy', '-no-color', '-force')
 APPLY_ARGS = ('apply', '-no-color', '-input=false', '-auto-approve=true')
 module = None
-
 current_DateTime = datetime.now().strftime("%d/%m/%Y %H:%M:$S")
 
-def preflight_validation(bin_path, project_path, log_error_path, variables_args=None, plan_file=None):   
-    dir_name = log_error_path    
+def preflight_validation(bin_path, project_path, log_error_path, variables_args=None, plan_file=None):
+    dir_name = log_error_path
     if project_path in [None, ''] or '/' not in project_path:
         module.fail_json(msg="Path for Terraform project can not be None or ''.")
     if not os.path.exists(bin_path):
@@ -183,33 +181,31 @@ def preflight_validation(bin_path, project_path, log_error_path, variables_args=
         module.fail_json(msg="Path for Terraform project '{0}' doesn't exist on this host - check the path and try again please.".format(project_path))
 
     rc, out, err = module.run_command([bin_path, 'validate'] + variables_args, cwd=project_path, use_unsafe_shell=True)
-    if rc != 0:      
+    if rc != 0:
       with open(dir_name, 'a+', newline='') as file_op:
         writer = csv.writer(file_op)
         writer.writerow(StringIO("ERROR RECORDED on "+ current_DateTime + '\r\n' + err))
-      module.fail_json(msg="Failed to validate Terraform configuration files:\r\n{0}".format(err))    
+      module.fail_json(msg="Failed to validate Terraform configuration files:\r\n{0}".format(err))
 
 
 def create_error_file_and_directory(log_error_path):
   error_directory_name, error_file_name = os.path.split(log_error_path)
   if not os.path.exists(error_directory_name):
     os.makedirs(error_directory_name)
-  
+
   if not os.path.exists(log_error_path):
     with open(log_error_path, 'w') as file:
       writer = csv.writer(file, delimiter=',')
       writer.writerow(StringIO(file))
 
 
-
-      
 def _state_args(state_file):
       if state_file and os.path.exists(state_file):
           return ['-state', state_file]
       if state_file and not os.path.exists(state_file):
           module.fail_json(msg='Could not find state_file "{0}", check the path and try again.'.format(state_file))
       return []
- 
+
 
 def init_plugins(bin_path, project_path, backend_config):
     command = [bin_path, 'init', '-input=false']
@@ -224,7 +220,7 @@ def init_plugins(bin_path, project_path, backend_config):
         module.fail_json(msg="Failed to initialize Terraform modules:\r\n{0}".format(err))
 
 
-def get_workspace_context(bin_path, project_path): 
+def get_workspace_context(bin_path, project_path):
     workspace_ctx = {"current": "default", "all": []}
     command = [bin_path, 'workspace', 'list', '-no-color']
     rc, out, err = module.run_command(command, cwd=project_path)
@@ -239,8 +235,6 @@ def get_workspace_context(bin_path, project_path):
         else:
             workspace_ctx["all"].append(stripped_item)
     return workspace_ctx
- 
-
 
 def _workspace_cmd(bin_path, project_path, action, workspace):
     command = [bin_path, 'workspace', action, workspace, '-no-color']
@@ -249,20 +243,16 @@ def _workspace_cmd(bin_path, project_path, action, workspace):
         module.fail_json(msg="Failed to {0} workspace:\r\n{1}".format(action, err))
     return rc, out, err
 
-
 def create_workspace(bin_path, project_path, workspace):
     _workspace_cmd(bin_path, project_path, 'new', workspace)
-
 
 def select_workspace(bin_path, project_path, workspace):
     _workspace_cmd(bin_path, project_path, 'select', workspace)
 
-
 def remove_workspace(bin_path, project_path, workspace):
     _workspace_cmd(bin_path, project_path, 'delete', workspace)
 
-
-def build_plan(command, project_path, variables_args, state_file, targets, state, plan_path=None):  
+def build_plan(command, project_path, variables_args, state_file, targets, state, plan_path=None):
     if plan_path is None:
         f, plan_path = tempfile.mkstemp(suffix='.tfplan')
 
@@ -286,7 +276,6 @@ def build_plan(command, project_path, variables_args, state_file, targets, state
         return plan_path, True, out, err, plan_command if state == 'planned' else command
 
     module.fail_json(msg='Terraform plan failed with unexpected exit code {0}. \r\nSTDOUT: {1}\r\n\r\nSTDERR: {2}'.format(rc, out, err))
-  
 
 def main():
     global module
@@ -357,7 +346,7 @@ def main():
     if variables_file:
         variables_args.extend(['-var-file', variables_file])
 
-    preflight_validation(command[0], project_path,log_error_path, variables_args)
+    preflight_validation(command[0], project_path, log_error_path, variables_args)
 
     #LOCK MODULE
     if module.params.get('lock') is not None:
@@ -375,8 +364,6 @@ def main():
     needs_application, changed = True, False
 
     out, err = '', ''
-
-    
 
     if state == 'absent':
         command.extend(variables_args)


### PR DESCRIPTION
**SUMMARY**

Often, plans will be executed in the background as part of an automation, perhaps from a CI/ CI pipeline. The current change stores the stdout/stderr from Terraform somewhere if there are any issues running the plan. Additionally, since the plans dynamically is created, templated from jinja 2. The current change stores the interpolated result that is actually executed as well so that we can refer to something concrete when looking at the logs.

fix to #12 

**ISSUE TYPE**

    Feature Pull Request

**COMPONENT NAME**

    terraform module

**ADDITIONAL INFORMATION**

The current change it useful for user to get all the logs of errors to able able to make future decisions with these error messages. For instances, running the command `state: present` with a wrong resource name. The error will be recorded with the time this error happened.

```
---
    - name : Testing existing module
      hosts: localhost    
      tasks: 
        - name: terraform basic
          terraform:
              project_path: 'hekuro-app-/'
              log_error_path: './path_for_error/error.csv'
              #force_init: true
              state: present
          register: output    
        - debug:
             msg: '{{ output }}' 
```
