### PR TITLE
Terraform logging

### DIFF
--- a/changelogs/fragments/574-logging-terraform-outcomes.yaml
+++ b/changelogs/fragments/574-logging-terraform-outcomes.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - terraform - extra parameters(plan_id, log_activity_folder, file_name) are added to log outcomes from 
+  a terraform command. (https://github.com/ansible-collections/community.general/pull/574).

--- a/changelogs/fragments/574-logging-terraform-outcomes.yaml
+++ b/changelogs/fragments/574-logging-terraform-outcomes.yaml
@@ -1,3 +1,0 @@
-minor_changes:
-  - terraform - extra parameters(plan_id, log_activity_folder, file_name) are added to log outcomes from 
-  a terraform command. (https://github.com/ansible-collections/community.general/pull/574).

--- a/tests/unit/plugins/modules/cloud/misc/test_terraform.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_terraform.py
@@ -1,12 +1,188 @@
-# Copyright: (c) 2019, Ansible Project
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
 import json
-
 import pytest
-
 from ansible_collections.community.general.plugins.modules.cloud.misc import terraform
-from ansible_collections.community.general.tests.unit.plugins.modules.utils import set_module_args
+import mock
+import os
+
+from ansible.module_utils._text import to_bytes
+from ansible.module_utils import basic
+
+
+def set_module_args(args):
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def fail_json(*args, **kwargs):
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def exit_json(*args, **kwargs):
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+
+    raise AnsibleExitJson(kwargs)
+
+
+def test_state_args():
+    module = mock.MagicMock()
+    module.fail_json.side_effect = AnsibleFailJson(Exception)
+    with pytest.raises(AnsibleFailJson):
+        terraform._state_args(module, '/rrrr')
+    module.fail_json.assert_called()
+
+
+def test_returned_value_state_args(tmpdir):
+    test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
+    test_file = test_temp_folder_for_project_path.join("test_file.txt")
+    module = mock.MagicMock()
+    module.fail_json.side_effect = AnsibleFailJson(Exception)
+    value = terraform._state_args(module, test_file.dirname)
+    assert value == ['-state', test_file.dirname]
+
+
+def test_return_empty_list_state_args():
+    module = mock.MagicMock()
+    module.fail_json.side_effect = AnsibleFailJson(Exception)
+    value = terraform._state_args(module, '')
+    assert value == []
+
+
+def test_fail_json_preflight_validation_with_project_path_not_provided():
+    module = mock.MagicMock()
+    module.fail_json.side_effect = AnsibleFailJson(Exception)
+    with pytest.raises(AnsibleFailJson):
+        terraform.preflight_validation(module, '', '/rri')
+
+    module.fail_json.assert_called()
+
+
+def test_preflight_validation_with_arguments_satisfied_but_with_error_code_returned(tmpdir):
+    test_project_path = tmpdir.mkdir("project-path")
+    test_file = test_project_path.join("test_file.txt")
+    module = mock.MagicMock()
+    module.fail_json.side_effect = AnsibleFailJson(Exception)
+    module.run_command = mock.MagicMock()
+    module.run_command.return_value = (1, '', '')
+    with pytest.raises(AnsibleFailJson) as result:
+        terraform.preflight_validation(module, '/', test_file.dirname, [''])
+    module.fail_json.assert_called()
+
+
+def test_preflight_validation_with_arguments_satisfied_without_error_code(tmpdir):
+    test_project_path = tmpdir.mkdir("project-path")
+    test_file = test_project_path.join("test_file.txt")
+    module = mock.MagicMock()
+    module.fail_json.side_effect = AnsibleFailJson(Exception)
+    module.run_command = mock.MagicMock()
+    module.run_command.return_value = (0, '', '')
+    terraform.preflight_validation(module, '/', test_file.dirname, [''])
+
+    module.fail_json.assert_not_called()
+
+
+def test_get_workspace_context(tmpdir):
+    test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
+    test_file = test_temp_folder_for_project_path.join("test_file.txt")
+    module = mock.MagicMock()
+    module.run_command = mock.MagicMock()
+    out = '''
+    default
+    * turntabl
+    office
+    '''
+    module.run_command.return_value = (0, out, '')
+    returned_results = terraform.get_workspace_context(module, test_file.dirname, test_file.dirname)
+    expected_results = {'current': 'turntabl', 'all': ['default', 'office']}
+    assert returned_results == expected_results
+
+
+def test_build_plan_with_state_planned(tmpdir):
+    test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
+    test_file = test_temp_folder_for_project_path.join("test_file.tfplan")
+    full_path = os.path.join(test_file.dirname, test_file.basename)
+    module = mock.MagicMock()
+    module.run_command = mock.MagicMock()
+    module.run_command.return_value = (0, '', '')
+    returned_tuple_results = terraform.build_plan(module, [test_file.dirname], test_file.dirname, [], '', [], 'planned', full_path)
+    print(returned_tuple_results)
+    assert returned_tuple_results == (full_path, False, '', '', [test_file.dirname, 'plan', '-input=false',
+                                                                 '-no-color', '-detailed-exitcode', '-out', full_path])
+
+
+def test_build_plan_with_state_not_planned_and_return_code_zero(tmpdir):
+    test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
+    test_file = test_temp_folder_for_project_path.join("test_file.tfplan")
+    full_path = os.path.join(test_file.dirname, test_file.basename)
+    module = mock.MagicMock()
+    module.run_command = mock.MagicMock()
+    module.run_command.return_value = (0, '', '')
+    returned_tuple_results = terraform.build_plan(module, [test_file.dirname], test_file.dirname, [], '', [], 'present', full_path)
+    assert returned_tuple_results == (full_path, False, '', '', [test_file.dirname])
+
+
+def test_build_plan_with_state_planned_with_returned_code_one(tmpdir):
+    test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
+    test_file = test_temp_folder_for_project_path.join("test_file.tfplan")
+    full_path = os.path.join(test_file.dirname, test_file.basename)
+    module = mock.MagicMock()
+    module.run_command = mock.MagicMock()
+    module.fail_json.side_effect = AnsibleFailJson(Exception)
+    module.run_command.return_value = (1, '', '')
+    with pytest.raises(AnsibleFailJson) as result:
+        returned_tuple_results = terraform.build_plan(module, [test_file.dirname], test_file.dirname, [], '', [], 'planned', full_path)
+    module.fail_json.assert_called()
+
+
+def test_build_plan_with_state_planned_with_return_code_two(tmpdir):
+    test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
+    test_file = test_temp_folder_for_project_path.join("test_file.tfplan")
+    full_path = os.path.join(test_file.dirname, test_file.basename)
+    module = mock.MagicMock()
+    module.run_command = mock.MagicMock()
+    module.run_command.return_value = (2, '', '')
+    returned_tuple_results = terraform.build_plan(module, [test_file.dirname], test_file.dirname, [], '', [], 'planned', full_path)
+    assert returned_tuple_results == (full_path, True, '', '', [test_file.dirname, 'plan', '-input=false', '-no-color',
+                                                                '-detailed-exitcode', '-out', full_path])
+
+
+def test_build_plan_with_state_not_planned_with_return_code_two(tmpdir):
+    test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
+    test_file = test_temp_folder_for_project_path.join("test_file.tfplan")
+    full_path = os.path.join(test_file.dirname, test_file.basename)
+    module = mock.MagicMock()
+    module.run_command = mock.MagicMock()
+    module.run_command.return_value = (2, '', '')
+    returned_tuple_results = terraform.build_plan(module, [test_file.dirname], test_file.dirname, [], '', [], 'absent', full_path)
+    assert returned_tuple_results == (full_path, True, '', '', [test_file.dirname])
+
+
+def test_build_plan_with_return_code_greater_than_two(tmpdir):
+    test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
+    test_file = test_temp_folder_for_project_path.join("test_file.tfplan")
+    full_path = os.path.join(test_file.dirname, test_file.basename)
+    module = mock.MagicMock()
+    module.run_command = mock.MagicMock()
+    module.fail_json.side_effect = AnsibleFailJson(Exception)
+    module.run_command.return_value = (3, '', '')
+    with pytest.raises(AnsibleFailJson) as result:
+        returned_tuple_results = terraform.build_plan(module, [test_file.dirname], test_file.dirname, [], '', [], 'absent', full_path)
+    module.fail_json.assert_called()
+
+
+def test_get_plan_file_name_without_extension():
+    returned_result = terraform.get_plan_file_name_without_extension('./heroku-test/tmpNY45T.tfplan')
+    expected_result = 'tmpNY45T'
+    assert returned_result == expected_result
 
 
 def test_terraform_without_argument(capfd):

--- a/tests/unit/plugins/modules/cloud/misc/test_terraform.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_terraform.py
@@ -4,11 +4,190 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import json
-
 import pytest
-
 from ansible_collections.community.general.plugins.modules.cloud.misc import terraform
-from ansible_collections.community.general.tests.unit.plugins.modules.utils import set_module_args
+import mock
+import os
+
+from ansible.module_utils._text import to_bytes
+from ansible.module_utils import basic
+
+
+def set_module_args(args):
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def fail_json(*args, **kwargs):
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def exit_json(*args, **kwargs):
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+
+    raise AnsibleExitJson(kwargs)
+
+
+def test_state_args():
+    module = mock.MagicMock()
+    module.fail_json.side_effect = AnsibleFailJson(Exception)
+    with pytest.raises(AnsibleFailJson):
+        terraform._state_args(module, '/rrrr')
+    module.fail_json.assert_called()
+
+
+def test_returned_value_state_args(tmpdir):
+    test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
+    test_file = test_temp_folder_for_project_path.join("test_file.txt")
+    module = mock.MagicMock()
+    module.fail_json.side_effect = AnsibleFailJson(Exception)
+    value = terraform._state_args(module, test_file.dirname)
+    assert value == ['-state', test_file.dirname]
+
+
+def test_return_empty_list_state_args():
+    module = mock.MagicMock()
+    module.fail_json.side_effect = AnsibleFailJson(Exception)
+    value = terraform._state_args(module, '')
+    assert value == []
+
+
+def test_fail_json_preflight_validation_with_project_path_not_provided():
+    module = mock.MagicMock()
+    module.fail_json.side_effect = AnsibleFailJson(Exception)
+    with pytest.raises(AnsibleFailJson):
+        terraform.preflight_validation(module, '', '/rri')
+
+    module.fail_json.assert_called()
+
+
+def test_preflight_validation_with_arguments_satisfied_but_with_error_code_returned(tmpdir):
+    test_project_path = tmpdir.mkdir("project-path")
+    test_file = test_project_path.join("test_file.txt")
+    module = mock.MagicMock()
+    module.fail_json.side_effect = AnsibleFailJson(Exception)
+    module.run_command = mock.MagicMock()
+    module.run_command.return_value = (1, '', '')
+    with pytest.raises(AnsibleFailJson) as result:
+        terraform.preflight_validation(module, '/', test_file.dirname, [''])
+    module.fail_json.assert_called()
+
+
+def test_preflight_validation_with_arguments_satisfied_without_error_code(tmpdir):
+    test_project_path = tmpdir.mkdir("project-path")
+    test_file = test_project_path.join("test_file.txt")
+    module = mock.MagicMock()
+    module.fail_json.side_effect = AnsibleFailJson(Exception)
+    module.run_command = mock.MagicMock()
+    module.run_command.return_value = (0, '', '')
+    terraform.preflight_validation(module, '/', test_file.dirname, [''])
+
+    module.fail_json.assert_not_called()
+
+
+def test_get_workspace_context(tmpdir):
+    test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
+    test_file = test_temp_folder_for_project_path.join("test_file.txt")
+    module = mock.MagicMock()
+    module.run_command = mock.MagicMock()
+    out = '''
+    default
+    * turntabl
+    office
+    '''
+    module.run_command.return_value = (0, out, '')
+    returned_results = terraform.get_workspace_context(module, test_file.dirname, test_file.dirname)
+    expected_results = {'current': 'turntabl', 'all': ['default', 'office']}
+    assert returned_results == expected_results
+
+
+def test_build_plan_with_state_planned(tmpdir):
+    test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
+    test_file = test_temp_folder_for_project_path.join("test_file.tfplan")
+    full_path = os.path.join(test_file.dirname, test_file.basename)
+    module = mock.MagicMock()
+    module.run_command = mock.MagicMock()
+    module.run_command.return_value = (0, '', '')
+    returned_tuple_results = terraform.build_plan(module, [test_file.dirname], test_file.dirname, [], '', [], 'planned', full_path)
+    print(returned_tuple_results)
+    assert returned_tuple_results == (full_path, False, '', '', [test_file.dirname, 'plan', '-input=false',
+                                                                 '-no-color', '-detailed-exitcode', '-out', full_path])
+
+
+def test_build_plan_with_state_not_planned_and_return_code_zero(tmpdir):
+    test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
+    test_file = test_temp_folder_for_project_path.join("test_file.tfplan")
+    full_path = os.path.join(test_file.dirname, test_file.basename)
+    module = mock.MagicMock()
+    module.run_command = mock.MagicMock()
+    module.run_command.return_value = (0, '', '')
+    returned_tuple_results = terraform.build_plan(module, [test_file.dirname], test_file.dirname, [], '', [], 'present', full_path)
+    assert returned_tuple_results == (full_path, False, '', '', [test_file.dirname])
+
+
+def test_build_plan_with_state_planned_with_returned_code_one(tmpdir):
+    test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
+    test_file = test_temp_folder_for_project_path.join("test_file.tfplan")
+    full_path = os.path.join(test_file.dirname, test_file.basename)
+    module = mock.MagicMock()
+    module.run_command = mock.MagicMock()
+    module.fail_json.side_effect = AnsibleFailJson(Exception)
+    module.run_command.return_value = (1, '', '')
+    with pytest.raises(AnsibleFailJson) as result:
+        returned_tuple_results = terraform.build_plan(module, [test_file.dirname], test_file.dirname, [], '', [], 'planned', full_path)
+    module.fail_json.assert_called()
+
+
+def test_build_plan_with_state_planned_with_return_code_two(tmpdir):
+    test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
+    test_file = test_temp_folder_for_project_path.join("test_file.tfplan")
+    full_path = os.path.join(test_file.dirname, test_file.basename)
+    module = mock.MagicMock()
+    module.run_command = mock.MagicMock()
+    module.run_command.return_value = (2, '', '')
+    returned_tuple_results = terraform.build_plan(module, [test_file.dirname], test_file.dirname, [], '', [], 'planned', full_path)
+    assert returned_tuple_results == (full_path, True, '', '', [test_file.dirname, 'plan', '-input=false', '-no-color',
+                                                                '-detailed-exitcode', '-out', full_path])
+
+
+def test_build_plan_with_state_not_planned_with_return_code_two(tmpdir):
+    test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
+    test_file = test_temp_folder_for_project_path.join("test_file.tfplan")
+    full_path = os.path.join(test_file.dirname, test_file.basename)
+    module = mock.MagicMock()
+    module.run_command = mock.MagicMock()
+    module.run_command.return_value = (2, '', '')
+    returned_tuple_results = terraform.build_plan(module, [test_file.dirname], test_file.dirname, [], '', [], 'absent', full_path)
+    assert returned_tuple_results == (full_path, True, '', '', [test_file.dirname])
+
+
+def test_build_plan_with_return_code_greater_than_two(tmpdir):
+    test_temp_folder_for_project_path = tmpdir.mkdir("project-path")
+    test_file = test_temp_folder_for_project_path.join("test_file.tfplan")
+    full_path = os.path.join(test_file.dirname, test_file.basename)
+    module = mock.MagicMock()
+    module.run_command = mock.MagicMock()
+    module.fail_json.side_effect = AnsibleFailJson(Exception)
+    module.run_command.return_value = (3, '', '')
+    with pytest.raises(AnsibleFailJson) as result:
+        returned_tuple_results = terraform.build_plan(module, [test_file.dirname], test_file.dirname, [], '', [], 'absent', full_path)
+    module.fail_json.assert_called()
+
+
+def test_get_plan_file_name_without_extension():
+    returned_result = terraform.get_plan_file_name_without_extension('./heroku-test/tmpNY45T.tfplan')
+    expected_result = 'tmpNY45T'
+    assert returned_result == expected_result
 
 
 def test_terraform_without_argument(capfd):


### PR DESCRIPTION
##### SUMMARY
Added the functionality to log activities (example performing a terraform apply, run or destroy, outcomes(number of resources added or destroyed or changed)) in a json format into an audit file.

format:
`  {
         'time': timestamp,
         'plan_used': plan_used,
         'command_run': command_used,
         'outcome': outcome,
         'resources_added': list_creation,
         'resources_changed': list_modification,
         'resources_destroyed': list_destruction
         }`

The current module creates a temporary plan files every time you run the 'apply' command or a 'plan' command  if you do not provide a path to a plan_file. 

The contents of the audit file helps to retrieve the path to last plan file generated automatically by the module when the 'plan' command was run so that the user has the option to reuse the plan file generated by providing an id that would be displayed to the user upon running the 'plan' command without providing a path to the plan file.

Also added test cases for some already existing functions in the module.

Fixes to [#5 ](https://github.com/turntabl/community.general/issues/5) and [#3](https://github.com/turntabl/community.general/issues/3)

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
terraform module

##### ADDITIONAL INFORMATION

The model currently takes additional parameters `plan_id` provided by the user in case they might wish to reuse a plan file, `log_activity_folder`  path to a folder to containing the file to log the activities as stated earlier, and `file_name` to create the audit file and name the file with. 

If the user does not provide the `plan_id` and a `plan_path` and he or she performs a plan before an apply, the module retrieves the path to the last plan file generated by the user from the audit file and uses that plan file.
 
The already existing functions in the module did not have test cases so a few test cases have been added.

example:

playbook.yml:
```
- name: terraform 
    terraform:
      project_path: '/tmp/project/'
      plan_id: 'tmpER44'
      log_activity_folder: '/home/user/'
      file_name: 'jnnj4444'
      state: present
      check_deletes: True

```

when this playbook is executed it will create a file named `jnnj4444` in the `/home/user/` directory.
contents of `jnnj4444`:
`
[
    {
        "plan_used": "/tmp/tmpER44.tfplan",
        "resources_added": [],
        "resources_destroyed": [],
        "time": "21-05-2020 23:51:08",
        "command_run": "apply",
        "outcome": "Apply complete! Resources: 0 added, 0 changed, 0 destroyed."   
        "resources_changed": []
     }
]
`